### PR TITLE
Increase image version for dotnet

### DIFF
--- a/ReplicatedLogMaster/Dockerfile
+++ b/ReplicatedLogMaster/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 2100
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["ReplicatedLogMaster.csproj", ""]
 RUN dotnet restore "./ReplicatedLogMaster.csproj"


### PR DESCRIPTION
Using newer version will allow us to build and run dotnet images on M1 computers with arm architecture 